### PR TITLE
Mettre à jour la table de auto_update_rule_projects

### DIFF
--- a/app/models/auto_update_rule.rb
+++ b/app/models/auto_update_rule.rb
@@ -13,7 +13,7 @@ class AutoUpdateRule < ActiveRecord::Base
   validates_presence_of :author_id
 
   belongs_to :project # TODO Remove this association later, after migration
-  has_many :auto_update_rule_projects
+  has_many :auto_update_rule_projects, :dependent => :destroy
   has_many :projects, through: :auto_update_rule_projects
   belongs_to :author, class_name: 'User', foreign_key: :author_id
 

--- a/lib/redmine_auto_update_status/project_patch.rb
+++ b/lib/redmine_auto_update_status/project_patch.rb
@@ -1,6 +1,6 @@
 require_dependency 'project'
 
 class Project
-  has_many :auto_update_rule_projects
+  has_many :auto_update_rule_projects, :dependent => :destroy
   has_many :auto_update_rules, through: :auto_update_rule_projects
 end

--- a/spec/models/auto_update_rule_spec.rb
+++ b/spec/models/auto_update_rule_spec.rb
@@ -235,4 +235,23 @@ RSpec.describe AutoUpdateRule, :type => :model do
       expect(rule.limit_date_without_working_days(delay: 10, date: Date.parse("2022-06-20"))).to eq Date.parse("2022-06-06")
     end
   end
+
+  context "Update auto_update_rule_projects table in case of cascade deleting" do
+    let(:project) { Project.last }
+    before do
+      AutoUpdateRuleProject.create(project: project, auto_update_rule: rule)
+    end
+
+    it "When delete a rule" do
+      expect do
+        rule.destroy
+      end.to change { AutoUpdateRuleProject.count }.by(-1)
+    end
+
+    it "When delete a project" do
+      expect do
+        project.destroy
+      end.to change { AutoUpdateRuleProject.count }.by(-1)
+    end
+  end
 end


### PR DESCRIPTION
- Ajouter les dépendances pour mettre à jour la table de auto_update_rule_projects en cas de suppression de (project, auto_update_rule)
- Test